### PR TITLE
winusb: BonDriver_PX4: エラー発生時の MessageBox を表示しない設定を追加

### DIFF
--- a/winusb/pkg/BonDriver_PX4/BonDriver_PX-MLT.ini
+++ b/winusb/pkg/BonDriver_PX4/BonDriver_PX-MLT.ini
@@ -8,6 +8,7 @@ NumberOfPacketsPerBuffer=1024
 MaximumNumberOfBuffers=64
 MinimumNumberOfBuffers=4
 NumberOfBuffersToIgnoreAfterPurge=1
+DisplayErrorMessage=0
 
 [BonDriver.ISDB-T]
 ChSetPath="BonDriver_PX4-T.ChSet.txt"

--- a/winusb/pkg/BonDriver_PX4/BonDriver_PX4-S.ini
+++ b/winusb/pkg/BonDriver_PX4/BonDriver_PX4-S.ini
@@ -8,6 +8,7 @@ NumberOfPacketsPerBuffer=1024
 MaximumNumberOfBuffers=64
 MinimumNumberOfBuffers=4
 NumberOfBuffersToIgnoreAfterPurge=0
+DisplayErrorMessage=0
 
 [BonDriver.ISDB-S]
 ChSetPath="BonDriver_PX4-S.ChSet.txt"

--- a/winusb/pkg/BonDriver_PX4/BonDriver_PX4-T.ini
+++ b/winusb/pkg/BonDriver_PX4/BonDriver_PX4-T.ini
@@ -8,6 +8,7 @@ NumberOfPacketsPerBuffer=1024
 MaximumNumberOfBuffers=64
 MinimumNumberOfBuffers=4
 NumberOfBuffersToIgnoreAfterPurge=0
+DisplayErrorMessage=0
 
 [BonDriver.ISDB-T]
 ChSetPath="BonDriver_PX4-T.ChSet.txt"

--- a/winusb/src/BonDriver_PX4/bon_driver.hpp
+++ b/winusb/src/BonDriver_PX4/bon_driver.hpp
@@ -89,6 +89,7 @@ private:
 	std::unique_ptr<px4::PipeClient> data_pipe_;
 	BOOL open_;
 	DWORD space_, ch_;
+	BOOL display_error_message_;
 
 	std::mutex stream_mtx_;
 	std::unique_ptr<px4::IoQueue> ioq_;


### PR DESCRIPTION
https://github.com/nns779/px4_drv/issues/15 にて Issue を立てさせていただきましたが、実際に ini ファイルの設定でエラー発生時にメッセージボックスでエラーメッセージを表示するかどうかを設定できるようにしてみました。

BonDriver_PX4-T/S.ini 内の `DisplayErrorMessage` を `1` に設定すると、今まで通りチューナー不足などの際にメッセージボックスが表示されます。
`DisplayErrorMessage` を `0` やその他の値に設定した場合はメッセージボックスは表示されず、TVTest であればすぐに「BonDriver の初期化ができません」と表示されます。
なお、ini ファイルの設定に `DisplayErrorMessage` 自体が定義されていない場合は、デフォルトでメッセージボックスを表示しません。

TVTest や EDCB で期待通りの動作をすることは確認済みです。修正範囲からして動作自体への影響もないと思います。
よろしくお願いいたします。