### PR TITLE
driver: Linuxカーネルv6.4の関数シグニチャの変更に対応

### DIFF
--- a/driver/ptx_chrdev.c
+++ b/driver/ptx_chrdev.c
@@ -570,7 +570,7 @@ int ptx_chrdev_context_create(const char *name, const char *devname,
 
 	INIT_LIST_HEAD(&ctx->group_list);
 
-	ctx->class = class_create(THIS_MODULE, name);
+	ctx->class = class_create(name);
 	if (IS_ERR(ctx->class)) {
 		pr_err("ptx_chrdev_context_create: class_create(\"%s\") failed.\n",
 		       name);


### PR DESCRIPTION
Arch Linuxにて、カーネルを `6.4.1` に更新したところDKMSのビルドが失敗するようになりました。

```
DKMS make.log for px4_drv-0.2.1 for kernel 6.4.1-arch2-1 (x86_64)
Wed Jul  5 15:26:58 JST 2023
'revision.h' was updated.
  CC [M]  /var/lib/dkms/px4_drv/0.2.1/build/driver/driver_module.o
  CC [M]  /var/lib/dkms/px4_drv/0.2.1/build/driver/ptx_chrdev.o
In file included from ./include/linux/linkage.h:7,
                 from ./include/linux/preempt.h:10,
                 from ./include/linux/spinlock.h:56,
                 from ./include/linux/kref.h:16,
                 from /var/lib/dkms/px4_drv/0.2.1/build/driver/ptx_chrdev.h:13,
                 from /var/lib/dkms/px4_drv/0.2.1/build/driver/ptx_chrdev.c:9:
/var/lib/dkms/px4_drv/0.2.1/build/driver/ptx_chrdev.c: In function ‘ptx_chrdev_context_create’:
./include/linux/export.h:27:22: error: passing argument 1 of ‘class_create’ from incompatible pointer type [-Werror=incompatible-pointer-types]
   27 | #define THIS_MODULE (&__this_module)
      |                     ~^~~~~~~~~~~~~~~
      |                      |
      |                      struct module *
/var/lib/dkms/px4_drv/0.2.1/build/driver/ptx_chrdev.c:573:35: note: in expansion of macro ‘THIS_MODULE’
  573 |         ctx->class = class_create(THIS_MODULE, name);
      |                                   ^~~~~~~~~~~
In file included from ./include/linux/device.h:31,
                 from ./include/linux/cdev.h:8,
                 from /var/lib/dkms/px4_drv/0.2.1/build/driver/ptx_chrdev.h:16:
./include/linux/device/class.h:230:54: note: expected ‘const char *’ but argument is of type ‘struct module *’
  230 | struct class * __must_check class_create(const char *name);
      |                                          ~~~~~~~~~~~~^~~~
/var/lib/dkms/px4_drv/0.2.1/build/driver/ptx_chrdev.c:573:22: error: too many arguments to function ‘class_create’
  573 |         ctx->class = class_create(THIS_MODULE, name);
      |                      ^~~~~~~~~~~~
./include/linux/device/class.h:230:29: note: declared here
  230 | struct class * __must_check class_create(const char *name);
      |                             ^~~~~~~~~~~~
cc1: some warnings being treated as errors
make[2]: *** [scripts/Makefile.build:252: /var/lib/dkms/px4_drv/0.2.1/build/driver/ptx_chrdev.o] Error 1
make[1]: *** [Makefile:2026: /var/lib/dkms/px4_drv/0.2.1/build/driver] Error 2
make: *** [Makefile:19: px4_drv.ko] Error 2
```

下記コミットでの変更に対応し `class_create` の引数を削除しました。

https://github.com/torvalds/linux/commit/6e30a66433afee90e902ced95d7136e8f7edcc7e
https://github.com/torvalds/linux/commit/dcfbb67e48a2becfce7990386e985b9c45098ee5