### PR TITLE
Fix error: passing argument 1 of class_create

### DIFF
--- a/driver/ptx_chrdev.c
+++ b/driver/ptx_chrdev.c
@@ -14,6 +14,7 @@
 #include <linux/sched.h>
 #include <linux/uaccess.h>
 #include <linux/fs.h>
+#include <linux/version.h>
 
 static LIST_HEAD(ctx_list);
 static DEFINE_MUTEX(ctx_list_lock);
@@ -570,7 +571,11 @@ int ptx_chrdev_context_create(const char *name, const char *devname,
 
 	INIT_LIST_HEAD(&ctx->group_list);
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0)
 	ctx->class = class_create(THIS_MODULE, name);
+#else
+    ctx->class = class_create(name);
+#endif
 	if (IS_ERR(ctx->class)) {
 		pr_err("ptx_chrdev_context_create: class_create(\"%s\") failed.\n",
 		       name);


### PR DESCRIPTION
Fix the following error caused by the diff of kernel version.
```
make[1]: ディレクトリ '/usr/src/linux-headers-6.5.0-44-generic' に入ります
warning: the compiler differs from the one used to build the kernel
  The kernel was built by: x86_64-linux-gnu-gcc-12 (Ubuntu 12.3.0-1ubuntu1~22.04) 12.3.0
  You are using:           gcc-12 (Ubuntu 12.3.0-1ubuntu1~22.04) 12.3.0
  CC [M]  PX4_driver/px4_drv/driver/ptx_chrdev.o
In file included from ./include/linux/linkage.h:7,
                 from ./include/linux/preempt.h:10,
                 from ./include/linux/spinlock.h:56,
                 from ./include/linux/kref.h:16,
                 from PX4_driver/px4_drv/driver/ptx_chrdev.h:13,
                 from PX4_driver/px4_drv/driver/ptx_chrdev.c:9:
px4_drv/driver/ptx_chrdev.c: In function ‘ptx_chrdev_context_create’:
./include/linux/export.h:29:22: error: passing argument 1 of ‘class_create’ from incompatible pointer type [-Werror=incompatible-pointer-types]
   29 | #define THIS_MODULE (&__this_module)
      |                     ~^~~~~~~~~~~~~~~
      |                      |
      |                      struct module *
px4_drv/driver/ptx_chrdev.c:573:35: note: in expansion of macro ‘THIS_MODULE’
  573 |         ctx->class = class_create(THIS_MODULE, name);
      |                                   ^~~~~~~~~~~
In file included from ./include/linux/device.h:31,
                 from ./include/linux/cdev.h:8,
                 from DTV_folder/PX4_driver/px4_drv/driver/ptx_chrdev.h:16:
./include/linux/device/class.h:230:54: note: expected ‘const char *’ but argument is of type ‘struct module *’
  230 | struct class * __must_check class_create(const char *name);
      |                                          ~~~~~~~~~~~~^~~~
PX4_driver/px4_drv/driver/ptx_chrdev.c:573:22: error: too many arguments to function ‘class_create’
  573 |         ctx->class = class_create(THIS_MODULE, name);
      |                      ^~~~~~~~~~~~
./include/linux/device/class.h:230:29: note: declared here
  230 | struct class * __must_check class_create(const char *name);
      |                             ^~~~~~~~~~~~
cc1: some warnings being treated as errors
make[3]: *** [scripts/Makefile.build:251: PX4_driver/px4_drv/driver/ptx_chrdev.o] エラー 1
make[2]: *** [/usr/src/linux-headers-6.5.0-44-generic/Makefile:2039: DTV_folder/PX4_driver/px4_drv/driver] エラー 2
make[1]: *** [Makefile:234: __sub-make] エラー 2
make[1]: ディレクトリ '/usr/src/linux-headers-6.5.0-44-generic' から出ます
make: *** [Makefile:19: px4_drv.ko] エラー 2
```