### PR TITLE
fix: replace strlcpy with preferred strscpy

### DIFF
--- a/driver/ptx_chrdev.c
+++ b/driver/ptx_chrdev.c
@@ -566,7 +566,7 @@ int ptx_chrdev_context_create(const char *name, const char *devname,
 		return -ENOMEM;
 
 	mutex_init(&ctx->lock);
-	strlcpy(ctx->devname, devname, sizeof(ctx->devname));
+	strscpy(ctx->devname, devname, sizeof(ctx->devname));
 
 	INIT_LIST_HEAD(&ctx->group_list);
 


### PR DESCRIPTION
Since it is preferred to use `strscpy` over `strlcpy` for its insecurity, update the only one line where it is used.
This change also solves the build issue when GNU glibc cannot find `strlcpy` throwing the following error with recent environments:

```console
8:26 iomz@sazanka:~/ghq/github.com/nns779/px4_drv/driver
[develop|✚1…2] ❯❯❯ make
make[1]: Entering directory '/usr/src/linux-headers-6.8.0-47-generic'
warning: the compiler differs from the one used to build the kernel
  The kernel was built by: x86_64-linux-gnu-gcc-13 (Ubuntu 13.2.0-23ubuntu4) 13.2.0
  You are using:           gcc-13 (Ubuntu 13.2.0-23ubuntu4) 13.2.0
  CC [M]  /home/iomz/ghq/github.com/nns779/px4_drv/driver/ptx_chrdev.o
/home/iomz/ghq/github.com/nns779/px4_drv/driver/ptx_chrdev.c: In function ‘ptx_chrdev_context_create’:
/home/iomz/ghq/github.com/nns779/px4_drv/driver/ptx_chrdev.c:569:9: error: implicit declaration of function ‘strlcpy’; did you mean ‘strscpy’? [-Werror=implicit-function-declaration]
  569 |         strlcpy(ctx->devname, devname, sizeof(ctx->devname));
      |         ^~~~~~~
      |         strscpy
/home/iomz/ghq/github.com/nns779/px4_drv/driver/ptx_chrdev.c: At top level:
/home/iomz/ghq/github.com/nns779/px4_drv/driver/ptx_chrdev.c:727:5: warning: no previous prototype for ‘ptx_chrdev_context_reserve’ [-Wmissing-prototypes]
  727 | int ptx_chrdev_context_reserve(struct ptx_chrdev_context *chrdev_ctx,
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: some warnings being treated as errors
make[3]: *** [scripts/Makefile.build:243: /home/iomz/ghq/github.com/nns779/px4_drv/driver/ptx_chrdev.o] Error 1
make[2]: *** [/usr/src/linux-headers-6.8.0-47-generic/Makefile:1925: /home/iomz/ghq/github.com/nns779/px4_drv/driver] Error 2
make[1]: Leaving directory '/usr/src/linux-headers-6.8.0-47-generic'
make[1]: *** [Makefile:240: __sub-make] Error 2
make: *** [Makefile:19: px4_drv.ko] Error 2
```

cf. https://manpages.debian.org/testing/linux-manual-4.8/strscpy.9.en.html